### PR TITLE
Update lesson labels and Google Drive links

### DIFF
--- a/templates/resources.html
+++ b/templates/resources.html
@@ -75,13 +75,13 @@
             </div>
             <div class="lessoncontainer lesson2">
                 <div class='numwrap'><p class="lessonnum">2</p></div>
-                <div class='detailwrap'><p class="lessondetails"><strong></strong>Exemplar</p></div>
-                <div class="lessonwrap"><a href="https://drive.google.com/file/d/1MWKDEQ1bH65wbFqwjl3D1bKAzcBOdBhO/view" class="findthelesson-link linkclass"><p class="findthelesson">FIND THE LESSON</p></a></div>
+                <div class='detailwrap'><p class="lessondetails"><strong></strong>Lesson 2</p></div>
+                <div class="lessonwrap"><a href="https://drive.google.com/file/d/18DKwMCl_JbPYfCxBWYiJ4miJbnrLVHE7/view" class="findthelesson-link linkclass"><p class="findthelesson">FIND THE LESSON</p></a></div>
             </div>
             <div class="lessoncontainer lesson3">
                 <div class='numwrap'><p class="lessonnum">3</p></div>
-                <div class='detailwrap'><p class="lessondetails"><strong></strong>Lesson 1</p></div>
-                <div class="lessonwrap"><a href="https://drive.google.com/file/d/1Jm8ahZ34sGFtXnYjhScBshN09f6Urbin/view" class="findthelesson-link linkclass"><p class="findthelesson">FIND THE LESSON</p></a></div>
+                <div class='detailwrap'><p class="lessondetails"><strong></strong>Lesson 3</p></div>
+                <div class="lessonwrap"><a href="https://drive.google.com/file/d/1VrqgFu-zhM-Tr_SB6ETA6aW8krN9skuA/view" class="findthelesson-link linkclass"><p class="findthelesson">FIND THE LESSON</p></a></div>
             </div>
 
         </section>


### PR DESCRIPTION
Fix incorrect lesson labels and update the corresponding Google Drive URLs in templates/resources.html. 'Exemplar' was renamed to 'Lesson 2' and its link was replaced with the correct Drive file ID; 'Lesson 1' label was corrected to 'Lesson 3' and its link updated to the proper file URL. These changes correct mismatched labels and resources.