### PR TITLE
Update homepage text and social links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -178,7 +178,7 @@
             <div class="extra-format">
                 <label class="extra-info-subtitle">Our Competition</label>
                 <div class="extra-info-subtext">
-                    <p>Join SolveXchange and work alongside other inspired youth to develop your innovative ideas. Submit your proposal to our competition for a chance to win SolveXchange support, gain recognition and bring your idea to reality.</p>
+                    <p>Sign up for the SolveXchange Virtual Pitch Competition, which welcomes students from across the globe, and turn your ideas into real impact. Build a solution to a real-world problem, pitch it in 5 minutes, and compete for funding while gaining valuable skills in entrepreneurship and leadership.</p>
                 </div>
             </div>
             <div class="extra-format">
@@ -189,9 +189,9 @@
                 <a href="/getinvolved"><button class="global-button"  id="getinvolved-button2" type="button">Get Involved</button></a>
             </div>
             <div class="extra-format">
-                <label class="extra-info-subtitle">Join Our Exec Team</label>
+                <label class="extra-info-subtitle">Sponsor Us</label>
                 <div class="extra-info-subtext">
-                    <p>Are you passionate about the same goals we are? Do you possess skills or ideas that could improve SolveXchange? Join our executive team as we work together towards empowering more youth.</p>
+                    <p>Support the SolveXchange Virtual Pitch Competition, which welcomes students from across the globe, and help students turn their ideas into real impact. Your sponsorship helps fund innovative solutions and provides recognition across our platform and events. If you’re interested, email solvexchange.info@gmail.com.</p>
                 </div>
             </div>
         </div>
@@ -231,7 +231,7 @@
                 <p id="join-body-r-0">Connect With Us</p>
                 <div id="join-body-r-1-wrap"><img id="classroom" src="{{ url_for('static', filename='images/classroom.png') }}" width="35" height="27"><p id="join-body-r-1"><a class="white linkclass" target="_blank" href="https://classroom.google.com/c/NjE4MzQ1Mjg3NDcy?cjc=2aqmjab">Classroom</a></p></div>
                 <div id="join-body-r-2-wrap"><img id="insta" src="{{ url_for('static', filename='images/insta.png') }}" width="35" height="35" ><p id="join-body-r-2"><a class="white linkclass" target="_blank" href="https://www.instagram.com/solvexchange/">@solvexchange</a></p></div>
-                <div id="join-body-r-3-wrap"><img id="linkedin" src="{{ url_for('static', filename='images/linkedin.png') }}" width="35" height="35"><p id="join-body-r-3"><a class="white linkclass" target="_blank" href="https://www.linkedin.com/in/solvexchange-irhs-3b6526288/">SolveXchange</a></p></div>
+                <div id="join-body-r-3-wrap"><img id="linkedin" src="{{ url_for('static', filename='images/linkedin.png') }}" width="35" height="35"><p id="join-body-r-3"><a class="white linkclass" target="_blank" href="https://ca.linkedin.com/company/solvexchange">SolveXchange</a></p></div>
                 <div id="join-body-r-4-wrap"><img id="email" src="{{ url_for('static', filename='images/email.png') }}" width="35" height="25.68"><p id="join-body-r-4"><a class="white linkclass" target="_blank" href="https://mail.google.com/mail/u/0/?tf=cm&fs=1&to=solvexchange.info@gmail.com&hl=en-US">solvexchange gmail</a></p></div>
             </div>
         </div>


### PR DESCRIPTION
Revise copy in templates/index.html: expand the "Our Competition" blurb to promote the SolveXchange Virtual Pitch Competition, replace the "Join Our Exec Team" section with a "Sponsor Us" section (including sponsor contact email), and update the LinkedIn link to the company page (https://ca.linkedin.com/company/solvexchange). These changes clarify the program, solicit sponsorship, and correct the social link.