### PR TITLE
Refine email label and adjust resource comment

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -234,7 +234,7 @@
                 <div id="join-body-r-1-wrap"><img id="classroom" src="{{ url_for('static', filename='images/classroom.png') }}" width="35" height="27"><p id="join-body-r-1"><a class="white linkclass" target="_blank" href="https://classroom.google.com/c/NjE4MzQ1Mjg3NDcy?cjc=2aqmjab">Classroom</a></p></div>
                 <div id="join-body-r-2-wrap"><img id="insta" src="{{ url_for('static', filename='images/insta.png') }}" width="35" height="35" ><p id="join-body-r-2"><a class="white linkclass" target="_blank" href="https://www.instagram.com/solvexchange/">@solvexchange</a></p></div>
                 <div id="join-body-r-3-wrap"><img id="linkedin" src="{{ url_for('static', filename='images/linkedin.png') }}" width="35" height="35"><p id="join-body-r-3"><a class="white linkclass" target="_blank" href="https://ca.linkedin.com/company/solvexchange">SolveXchange</a></p></div>
-                <div id="join-body-r-4-wrap"><img id="email" src="{{ url_for('static', filename='images/email.png') }}" width="35" height="25.68"><p id="join-body-r-4"><a class="white linkclass" target="_blank" href="https://mail.google.com/mail/u/0/?tf=cm&fs=1&to=solvexchange.info@gmail.com&hl=en-US">solvexchange gmail</a></p></div>
+                <div id="join-body-r-4-wrap"><img id="email" src="{{ url_for('static', filename='images/email.png') }}" width="35" height="25.68"><p id="join-body-r-4"><a class="white linkclass" target="_blank" href="https://mail.google.com/mail/u/0/?tf=cm&fs=1&to=solvexchange.info@gmail.com&hl=en-US">solvexchange Mail</a></p></div>
             </div>
         </div>
 

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -142,9 +142,9 @@
                 <p class = "ptitle">Implementation, Feasibility & Resources</p>
                 </a>
                 <p class = "pdesc"><!--<br><br><a class="linkclass" href="">Lesson Worksheet</a>--> </p>
-                <p class="pdate"></p>
+                <p class="pdate"></p> 
             </div>
-            <!-- 
+            <!--   hi
             <div class="presentationwrap">
                 <img class="ptb" src="{{ url_for('static', filename='images/lesson5.png') }}">
                 <hr class="presentationimagedivider">


### PR DESCRIPTION
Update templates/index.html to change the email link text from "solvexchange gmail" to "solvexchange Mail" for presentation consistency. Minor whitespace/comment tweak in templates/resources.html (adds a small inline comment and adjusts spacing). No functional behavior changes.